### PR TITLE
fix use of `document.activeElement` in VoiceOver iOS

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ const textualElements = 'h1, h2, h3, h4, h5, h6, p, ul, dl, figure, img, table, 
 
 let layerIndex = 0;
 let layerStack = [];
+let activeElement;
 
 const cancelListener = event => {
   if( !layerStack.length || event.keyCode !== 27 ){
@@ -13,6 +14,12 @@ const cancelListener = event => {
   const topModal = layerStack[ 0 ].layer;
 
   topModal._dispatchEvent( 'cancel' );
+};
+
+const getActiveElement = event => {
+  if( event.target !== document.body ){
+    activeElement = event.target;
+  }
 };
 
 class Overlay {
@@ -405,7 +412,7 @@ class Overlay {
     // bind eventListeners to the layer
     this._bind();
     // store the current focused element before focusing the layer
-    this.options.opener = this.options.opener || document.activeElement;
+    this.options.opener = this.options.opener || activeElement;
     // IE can't focus a svg element
     if( this.options.opener.nodeName === 'svg' ){
       this.options.opener = this.options.opener.parentNode;
@@ -465,5 +472,6 @@ class Overlay {
 
 // listen to the escape key to close the top-most layer
 document.body.addEventListener( 'keydown', cancelListener );
+document.body.addEventListener( 'focus', getActiveElement, true );
 
 export default Overlay;


### PR DESCRIPTION
On VoiceOver iOS the `document.activeElement` property  always refers to `body` when an element is double tapped. To fix that a listener for the `focus` event was added. It's used to store the latest focused element except when the element is `body`.

You can always use the `opener` parameter when creating an overlay to specify the element that will be focused once the overlay is closed.